### PR TITLE
9/UI/legacy toolbar

### DIFF
--- a/Services/UIComponent/Toolbar/classes/class.ilToolbarGUI.php
+++ b/Services/UIComponent/Toolbar/classes/class.ilToolbarGUI.php
@@ -328,9 +328,9 @@ class ilToolbarGUI
                     $markup_items .= $tpl_separator->get();
                 }
                 foreach ($group as $item) {
+                    $tpl_items->setCurrentBlock("item");
                     switch ($item["type"]) {
                         case "button":
-                            $tpl_items->setCurrentBlock("button");
                             $tpl_items->setVariable("BTN_TXT", $item["txt"]);
                             $tpl_items->setVariable("BTN_LINK", $item["cmd"]);
                             if ($item["target"] != "") {
@@ -343,11 +343,11 @@ class ilToolbarGUI
                                 $tpl_items->setVariable('BTN_ADD_ARG', $item['add_attrs']);
                             }
                             $tpl_items->setVariable('BTN_CLASS', $item['class']);
-                            $tpl_items->parseCurrentBlock();
+                            //$tpl_items->parseCurrentBlock();
                             break;
 
                         case "fbutton":
-                            $tpl_items->setCurrentBlock("form_button");
+                            //$tpl_items->setCurrentBlock("form_button");
                             $tpl_items->setVariable("SUB_TXT", $item["txt"]);
                             $tpl_items->setVariable("SUB_CMD", $item["cmd"]);
                             if ($item["primary"]) {
@@ -355,75 +355,77 @@ class ilToolbarGUI
                             } elseif ($item["class"]) {
                                 $tpl_items->setVariable("SUB_CLASS", " " . $item["class"]);
                             }
-                            $tpl_items->parseCurrentBlock();
+                            //$tpl_items->parseCurrentBlock();
                             break;
 
                         case "button_obj":
-                            $tpl_items->setCurrentBlock("button_instance");
+                            //$tpl_items->setCurrentBlock("button_instance");
                             $tpl_items->setVariable("BUTTON_OBJ", $item["instance"]->render());
-                            $tpl_items->parseCurrentBlock();
+                            //$tpl_items->parseCurrentBlock();
                             break;
 
                         case "input":
                             if ($item["label"]) {
-                                $tpl_items->setCurrentBlock("input_label");
+                                //$tpl_items->setCurrentBlock("input_label");
                                 $tpl_items->setVariable("TXT_INPUT", $item["input"]->getTitle());
                                 $tpl_items->setVariable("INPUT_ID", $item["input"]->getFieldId());
-                                $tpl_items->parseCurrentBlock();
+                                //$tpl_items->parseCurrentBlock();
                             }
-                            $tpl_items->setCurrentBlock("input");
+                            //$tpl_items->setCurrentBlock("input");
                             $tpl_items->setVariable("INPUT_HTML", $item["input"]->getToolbarHTML());
-                            $tpl_items->parseCurrentBlock();
+                            //$tpl_items->parseCurrentBlock();
                             break;
 
                             // bs-patch start
                         case "dropdown":
-                            $tpl_items->setCurrentBlock("dropdown");
+                            //$tpl_items->setCurrentBlock("dropdown");
                             $tpl_items->setVariable("TXT_DROPDOWN", $item["txt"]);
                             $tpl_items->setVariable("DROP_DOWN", $item["dd_html"]);
-                            $tpl_items->parseCurrentBlock();
+                            //$tpl_items->parseCurrentBlock();
                             break;
                             // bs-patch end
                         case "text":
-                            $tpl_items->setCurrentBlock("text");
+                            //$tpl_items->setCurrentBlock("text");
                             $tpl_items->setVariable("VAL_TEXT", $item["text"]);
-                            $tpl_items->parseCurrentBlock();
+                            //$tpl_items->parseCurrentBlock();
                             break;
 
                         case "component":
-                            $tpl_items->setCurrentBlock("component");
+                            // $tpl_items->setCurrentBlock("component");
                             $tpl_items->setVariable("COMPONENT", $this->ui->renderer()->render($item["component"]));
-                            $tpl_items->parseCurrentBlock();
+                            //$tpl_items->parseCurrentBlock();
                             break;
 
                         case "adv_sel_list":
-                            $tpl_items->setCurrentBlock("component");
+                            //$tpl_items->setCurrentBlock("component");
                             $tpl_items->setVariable("COMPONENT", $item["list"]->getHTML());
                             $tpl_items->parseCurrentBlock();
                             break;
 
 
-                        case "spacer":
-                            $tpl_items->touchBlock("spacer");
-                            if (!$item["width"]) {
-                                $item["width"] = 2;
-                            }
-                            $tpl_items->setVariable("SPACER_WIDTH", $item["width"]);
-                            $tpl_items->parseCurrentBlock();
-                            break;
+                            /*
+                            case "spacer":
+                                $tpl_items->touchBlock("spacer");
+                                if (!$item["width"]) {
+                                    $item["width"] = 2;
+                                }
+                                $tpl_items->setVariable("SPACER_WIDTH", $item["width"]);
+                                $tpl_items->parseCurrentBlock();
+                                break;
+                            */
 
                         case "link":
                             if ($item["disabled"] == false) {
-                                $tpl_items->setCurrentBlock("link");
+                                //$tpl_items->setCurrentBlock("link");
                                 $tpl_items->setVariable("LINK_TXT", $item["txt"]);
                                 $tpl_items->setVariable("LINK_URL", $item["cmd"]);
                             } else {
-                                $tpl_items->setCurrentBlock("link_disabled");
+                                //$tpl_items->setCurrentBlock("link_disabled");
                                 $tpl_items->setVariable("LINK_DISABLED_TXT", $item["txt"]);
                             }
-                            $tpl_items->parseCurrentBlock();
                             break;
                     }
+                    $tpl_items->parseCurrentBlock();
                 }
 
                 if ($i > 0) {

--- a/Services/UIComponent/Toolbar/classes/class.ilToolbarGUI.php
+++ b/Services/UIComponent/Toolbar/classes/class.ilToolbarGUI.php
@@ -316,16 +316,9 @@ class ilToolbarGUI
                 $tpl->parseCurrentBlock();
             }
 
-            $groups = $this->getGroupedItems();
-
-            $multipleGroups = FALSE;
-            if (count($groups) > 1) {
-                $multipleGroups = TRUE;
-            }
-
             $markup_items = '';
-            foreach ($groups as $i => $group) {
-                $tpl_itemcontainer = new ilTemplate("tpl.toolbar_itemcontainer.html", true, true, "Services/UIComponent/Toolbar");
+            foreach ($this->getGroupedItems() as $i => $group) {
+                $tpl_items = new ilTemplate("tpl.toolbar_items.html", true, true, "Services/UIComponent/Toolbar");
                 if ($i > 0) {
                     static $tpl_separator;
                     if ($tpl_separator === null) {
@@ -334,84 +327,79 @@ class ilToolbarGUI
                     $tpl_separator->touchBlock('separator');
                     $markup_items .= $tpl_separator->get();
                 }
-
-                $groupitems = '';
-                
                 foreach ($group as $item) {
-                    $tpl_itemcontent = new ilTemplate("tpl.toolbar_itemcontent.html", true, true, "Services/UIComponent/Toolbar");
                     switch ($item["type"]) {
                         case "button":
-                            $tpl_itemcontent->setCurrentBlock("button");
-                            $tpl_itemcontent->setVariable("BTN_TXT", $item["txt"]);
-                            $tpl_itemcontent->setVariable("BTN_LINK", $item["cmd"]);
+                            $tpl_items->setCurrentBlock("button");
+                            $tpl_items->setVariable("BTN_TXT", $item["txt"]);
+                            $tpl_items->setVariable("BTN_LINK", $item["cmd"]);
                             if ($item["target"] != "") {
-                                $tpl_itemcontent->setVariable("BTN_TARGET", 'target="' . $item["target"] . '"');
+                                $tpl_items->setVariable("BTN_TARGET", 'target="' . $item["target"] . '"');
                             }
                             if ($item["id"] != "") {
-                                $tpl_itemcontent->setVariable("BID", 'id="' . $item["id"] . '"');
+                                $tpl_items->setVariable("BID", 'id="' . $item["id"] . '"');
                             }
                             if (($item['add_attrs'])) {
-                                $tpl_itemcontent->setVariable('BTN_ADD_ARG', $item['add_attrs']);
+                                $tpl_items->setVariable('BTN_ADD_ARG', $item['add_attrs']);
                             }
-                            $tpl_itemcontent->setVariable('BTN_CLASS', $item['class']);
-                            $tpl_itemcontent->parseCurrentBlock();
+                            $tpl_items->setVariable('BTN_CLASS', $item['class']);
+                            $tpl_items->parseCurrentBlock();
                             break;
 
                         case "fbutton":
-                            $tpl_itemcontent->setCurrentBlock("form_button");
-                            $tpl_itemcontent->setVariable("SUB_TXT", $item["txt"]);
-                            $tpl_itemcontent->setVariable("SUB_CMD", $item["cmd"]);
+                            $tpl_items->setCurrentBlock("form_button");
+                            $tpl_items->setVariable("SUB_TXT", $item["txt"]);
+                            $tpl_items->setVariable("SUB_CMD", $item["cmd"]);
                             if ($item["primary"]) {
-                                $tpl_itemcontent->setVariable("SUB_CLASS", " emphsubmit");
+                                $tpl_items->setVariable("SUB_CLASS", " emphsubmit");
                             } elseif ($item["class"]) {
-                                $tpl_itemcontent->setVariable("SUB_CLASS", " " . $item["class"]);
+                                $tpl_items->setVariable("SUB_CLASS", " " . $item["class"]);
                             }
-                            $tpl_itemcontent->parseCurrentBlock();
-                            $tpl_itemcontent->touchBlock("item");
+                            $tpl_items->parseCurrentBlock();
                             break;
 
                         case "button_obj":
-                            $tpl_itemcontent->setCurrentBlock("button_instance");
-                            $tpl_itemcontent->setVariable("BUTTON_OBJ", $item["instance"]->render());
-                            $tpl_itemcontent->parseCurrentBlock();
+                            $tpl_items->setCurrentBlock("button_instance");
+                            $tpl_items->setVariable("BUTTON_OBJ", $item["instance"]->render());
+                            $tpl_items->parseCurrentBlock();
                             break;
 
                         case "input":
                             if ($item["label"]) {
-                                $tpl_itemcontent->setCurrentBlock("input_label");
-                                $tpl_itemcontent->setVariable("TXT_INPUT", $item["input"]->getTitle());
-                                $tpl_itemcontent->setVariable("INPUT_ID", $item["input"]->getFieldId());
-                                $tpl_itemcontent->parseCurrentBlock();
+                                $tpl_items->setCurrentBlock("input_label");
+                                $tpl_items->setVariable("TXT_INPUT", $item["input"]->getTitle());
+                                $tpl_items->setVariable("INPUT_ID", $item["input"]->getFieldId());
+                                $tpl_items->parseCurrentBlock();
                             }
-                            $tpl_itemcontent->setCurrentBlock("input");
-                            $tpl_itemcontent->setVariable("INPUT_HTML", $item["input"]->getToolbarHTML());
-                            $tpl_itemcontent->parseCurrentBlock();
+                            $tpl_items->setCurrentBlock("input");
+                            $tpl_items->setVariable("INPUT_HTML", $item["input"]->getToolbarHTML());
+                            $tpl_items->parseCurrentBlock();
                             break;
 
                             // bs-patch start
                         case "dropdown":
-                            $tpl_itemcontent->setCurrentBlock("dropdown");
-                            $tpl_itemcontent->setVariable("TXT_DROPDOWN", $item["txt"]);
-                            $tpl_itemcontent->setVariable("DROP_DOWN", $item["dd_html"]);
-                            $tpl_itemcontent->parseCurrentBlock();
+                            $tpl_items->setCurrentBlock("dropdown");
+                            $tpl_items->setVariable("TXT_DROPDOWN", $item["txt"]);
+                            $tpl_items->setVariable("DROP_DOWN", $item["dd_html"]);
+                            $tpl_items->parseCurrentBlock();
                             break;
                             // bs-patch end
                         case "text":
-                            $tpl_itemcontent->setCurrentBlock("text");
-                            $tpl_itemcontent->setVariable("VAL_TEXT", $item["text"]);
-                            $tpl_itemcontent->parseCurrentBlock();
+                            $tpl_items->setCurrentBlock("text");
+                            $tpl_items->setVariable("VAL_TEXT", $item["text"]);
+                            $tpl_items->parseCurrentBlock();
                             break;
 
                         case "component":
-                            $tpl_itemcontent->setCurrentBlock("component");
-                            $tpl_itemcontent->setVariable("COMPONENT", $this->ui->renderer()->render($item["component"]));
-                            $tpl_itemcontent->parseCurrentBlock();
+                            $tpl_items->setCurrentBlock("component");
+                            $tpl_items->setVariable("COMPONENT", $this->ui->renderer()->render($item["component"]));
+                            $tpl_items->parseCurrentBlock();
                             break;
 
                         case "adv_sel_list":
-                            $tpl_itemcontent->setCurrentBlock("component");
-                            $tpl_itemcontent->setVariable("COMPONENT", $item["list"]->getHTML());
-                            $tpl_itemcontent->parseCurrentBlock();
+                            $tpl_items->setCurrentBlock("component");
+                            $tpl_items->setVariable("COMPONENT", $item["list"]->getHTML());
+                            $tpl_items->parseCurrentBlock();
                             break;
 
 
@@ -420,37 +408,34 @@ class ilToolbarGUI
                             if (!$item["width"]) {
                                 $item["width"] = 2;
                             }
-                            $tpl_itemcontent->setVariable("SPACER_WIDTH", $item["width"]);
-                            $tpl_itemcontent->parseCurrentBlock();
+                            $tpl_items->setVariable("SPACER_WIDTH", $item["width"]);
+                            $tpl_items->parseCurrentBlock();
                             break;
 
                         case "link":
                             if ($item["disabled"] == false) {
-                                $tpl_itemcontent->setCurrentBlock("link");
-                                $tpl_itemcontent->setVariable("LINK_TXT", $item["txt"]);
-                                $tpl_itemcontent->setVariable("LINK_URL", $item["cmd"]);
+                                $tpl_items->setCurrentBlock("link");
+                                $tpl_items->setVariable("LINK_TXT", $item["txt"]);
+                                $tpl_items->setVariable("LINK_URL", $item["cmd"]);
                             } else {
-                                $tpl_itemcontent->setCurrentBlock("link_disabled");
-                                $tpl_itemcontent->setVariable("LINK_DISABLED_TXT", $item["txt"]);
+                                $tpl_items->setCurrentBlock("link_disabled");
+                                $tpl_items->setVariable("LINK_DISABLED_TXT", $item["txt"]);
                             }
-                            $tpl_itemcontent->parseCurrentBlock();
+                            $tpl_items->parseCurrentBlock();
                             break;
                     }
-                    $tpl_itemcontainer->setCurrentBlock("item");
-                    $tpl_itemcontainer->setVariable("ITEM_CONTENT", $tpl_itemcontent->get());
-                    $tpl_itemcontainer->parseCurrentBlock();
-                    $groupitems .=  $tpl_itemcontainer->get();
                 }
-                if ($multipleGroups) {
+
+                if ($i > 0) {
                     $tpl_itemgroups = new ilTemplate("tpl.toolbar_itemgroup.html", true, true, "Services/UIComponent/Toolbar");
                     $tpl_itemgroups->setCurrentBlock("itemgroup");
-                    $tpl_itemgroups->setVariable("ITEMS", $groupitems);
+                    $tpl_itemgroups->setVariable("ITEMS", $tpl_items->get());
+                    $tpl_itemgroups->parseCurrentBlock();
                     $markup_items .= $tpl_itemgroups->get();
                 } else {
-                    $markup_items .= $groupitems;
+                    $markup_items .= $tpl_items->get();
                 }
             }
-            
 
             $tpl->setVariable('ITEMS', $markup_items);
             $tpl->setVariable("TXT_FUNCTIONS", $lng->txt("functions"));

--- a/Services/UIComponent/Toolbar/templates/default/tpl.toolbar_items.html
+++ b/Services/UIComponent/Toolbar/templates/default/tpl.toolbar_items.html
@@ -1,0 +1,53 @@
+<!-- BEGIN button -->
+<div class="l-bar__element c-toolbar__item">
+	<div class="navbar-form"><button {BID} class="btn btn-default" type="button" onclick="location.href='{BTN_LINK}'" {BTN_ADD_ARG}>{BTN_TXT}</button></div>
+</div>
+<!-- END button -->
+
+<!-- BEGIN dropdown -->
+<div class="l-bar__element c-toolbar__item">
+	<a href="#" class="dropdown-toggle" data-toggle="dropdown">{TXT_DROPDOWN} <span class="caret"></span></a>{DROP_DOWN}
+</div>
+<!-- END dropdown -->
+
+<!-- BEGIN form_button -->
+<div class="l-bar__element c-toolbar__item">
+	<div class="navbar-form"><input class="btn btn-default" type="submit" name="cmd[{SUB_CMD}]" value="{SUB_TXT}" /></div>
+</div>
+<!-- END form_button -->
+
+<!-- BEGIN button_instance -->
+<div class="l-bar__element c-toolbar__item">
+	<div class="navbar-form">{BUTTON_OBJ}</div>
+</div>
+<!-- END button_instance -->
+
+<!-- BEGIN input -->
+<div class="l-bar__element c-toolbar__item">
+	<div class="navbar-form"><!-- BEGIN input_label --><label for="{INPUT_ID}">{TXT_INPUT}&nbsp;</label><!-- END input_label -->{INPUT_HTML}</div>
+</div>
+<!-- END input -->
+
+<!-- BEGIN link -->
+<div class="l-bar__element c-toolbar__item">
+	<a href="{LINK_URL}">{LINK_TXT}</a>
+</div>
+<!-- END link -->
+
+<!-- BEGIN text -->
+<div class="l-bar__element c-toolbar__item">
+	<div class="navbar-text">{VAL_TEXT}</div>
+</div>
+<!-- END text -->
+
+<!-- BEGIN component -->
+<div class="l-bar__element c-toolbar__item">
+	<div class="navbar-form">{COMPONENT}</div>
+</div>
+<!-- END component -->
+
+<!-- BEGIN link_disabled -->
+<div class="l-bar__element c-toolbar__item">
+	<span class="ilTableFootLight">{LINK_DISABLED_TXT}</span>
+</div>
+<!-- END link_disabled -->

--- a/Services/UIComponent/Toolbar/templates/default/tpl.toolbar_items.html
+++ b/Services/UIComponent/Toolbar/templates/default/tpl.toolbar_items.html
@@ -1,53 +1,39 @@
-<!-- BEGIN button -->
+<!-- BEGIN item -->
 <div class="l-bar__element c-toolbar__item">
+	<!-- BEGIN button -->
 	<div class="navbar-form"><button {BID} class="btn btn-default" type="button" onclick="location.href='{BTN_LINK}'" {BTN_ADD_ARG}>{BTN_TXT}</button></div>
-</div>
-<!-- END button -->
+	<!-- END button -->
 
-<!-- BEGIN dropdown -->
-<div class="l-bar__element c-toolbar__item">
+	<!-- BEGIN dropdown -->
 	<a href="#" class="dropdown-toggle" data-toggle="dropdown">{TXT_DROPDOWN} <span class="caret"></span></a>{DROP_DOWN}
-</div>
-<!-- END dropdown -->
+	<!-- END dropdown -->
 
-<!-- BEGIN form_button -->
-<div class="l-bar__element c-toolbar__item">
+	<!-- BEGIN form_button -->
 	<div class="navbar-form"><input class="btn btn-default" type="submit" name="cmd[{SUB_CMD}]" value="{SUB_TXT}" /></div>
-</div>
-<!-- END form_button -->
+	<!-- END form_button -->
 
-<!-- BEGIN button_instance -->
-<div class="l-bar__element c-toolbar__item">
+	<!-- BEGIN button_instance -->
 	<div class="navbar-form">{BUTTON_OBJ}</div>
-</div>
-<!-- END button_instance -->
+	<!-- END button_instance -->
 
-<!-- BEGIN input -->
-<div class="l-bar__element c-toolbar__item">
+	<!-- BEGIN input -->
 	<div class="navbar-form"><!-- BEGIN input_label --><label for="{INPUT_ID}">{TXT_INPUT}&nbsp;</label><!-- END input_label -->{INPUT_HTML}</div>
-</div>
-<!-- END input -->
+	<!-- END input -->
 
-<!-- BEGIN link -->
-<div class="l-bar__element c-toolbar__item">
+	<!-- BEGIN link -->
 	<a href="{LINK_URL}">{LINK_TXT}</a>
-</div>
-<!-- END link -->
+	<!-- END link -->
 
-<!-- BEGIN text -->
-<div class="l-bar__element c-toolbar__item">
+	<!-- BEGIN text -->
 	<div class="navbar-text">{VAL_TEXT}</div>
-</div>
-<!-- END text -->
+	<!-- END text -->
 
-<!-- BEGIN component -->
-<div class="l-bar__element c-toolbar__item">
+	<!-- BEGIN component -->
 	<div class="navbar-form">{COMPONENT}</div>
-</div>
-<!-- END component -->
+	<!-- END component -->
 
-<!-- BEGIN link_disabled -->
-<div class="l-bar__element c-toolbar__item">
+	<!-- BEGIN link_disabled -->
 	<span class="ilTableFootLight">{LINK_DISABLED_TXT}</span>
+	<!-- END link_disabled -->
 </div>
-<!-- END link_disabled -->
+<!-- END item -->


### PR DESCRIPTION
Im ersten commit habe ich die Änderungen and der ilToolbarGUI rückgänig gemacht und das template ganz naiv erweitert. 
Das ist einfach, lesbar und irgendwie klar, was passiert.

Im zweiten commit ist der Item-Block wieder drin, das funktionierrt dann so:
der item-Block muss mehrmals gerendert werden, deshalb ganz am Anfang "setCurrentBlock" und am Ende "parseCurrentBlock".
Alle Blöcke, in denen keine Variable angefasst wird, werden nicht gerendert. Das funktioniert, weil die Variablen alle unterschiedlich heißen.

ich weiß nicht, ob ich einen Spezialfall übersehe, aber so in etwa, oder?